### PR TITLE
Address case where postinstall contains npm run build

### DIFF
--- a/src/messages.js
+++ b/src/messages.js
@@ -70,6 +70,24 @@ If you do not make this change, then both your "build" and "postinstall" scripts
 executed when pushing to Heroku after ${changeDate}.`;
 }
 
+function movePostinstallToPostbuild(pkg) {
+  return `
+${emoji("⚠️  ")}This app ${chalk.bold("will")} be affected by upcoming changes!
+
+"postinstall": "${pkg.scripts.postinstall}"
+"build": "${pkg.scripts.build}"
+
+This "build" script is not currently being run when this app is pushed to Heroku, but
+Heroku will start running it automatically starting on ${changeDate}.
+
+${chalk.blue.bold(
+    'We suggest moving the "postinstall" script to "heroku-postbuild" and opting in to the new behavior.'
+  )}
+
+If you do not make this change, then both your "build" and "postinstall" scripts will be
+executed when pushing to Heroku after ${changeDate}.`;
+}
+
 function proposedChange(diff) {
   // take off the first 3 lines of the diff
   diff = diff.split(os.EOL).slice(3).join(os.EOL)
@@ -131,6 +149,7 @@ module.exports = {
   emptyHerokuPostbuild,
   removePostinstall,
   movePostinstallToBuild,
+  movePostinstallToPostbuild,
   proposedChange,
   changesWrittenSuccessfully,
   alreadyOptedIn,

--- a/test/fixtures/postinstall-contains-run-build/package.json
+++ b/test/fixtures/postinstall-contains-run-build/package.json
@@ -1,0 +1,48 @@
+{
+  "name": "test-fixture",
+  "version": "0.1.0",
+  "private": true,
+  "dependencies": {
+    "ansi-to-react": "^2.0.6",
+    "apollo-server-express": "^1.2.0",
+    "body-parser": "^1.18.2",
+    "concurrently": "^3.5.0",
+    "date-fns": "^1.28.5",
+    "debug": "^2.6.8",
+    "express": "^4.15.4",
+    "flow-bin": "^0.51.1",
+    "graphql": "^0.11.7",
+    "graphql-tools": "^2.11.0",
+    "helmet": "^3.8.1",
+    "history": "^4.6.3",
+    "link-react": "^3.0.0",
+    "lodash": "^4.17.4",
+    "node-fetch": "^1.7.2",
+    "query-string": "^5.0.0",
+    "react": "^15.6.1",
+    "react-dom": "^15.6.1",
+    "react-scripts": "1.0.10",
+    "url-pattern": "^1.0.3"
+  },
+  "devDependencies": {
+    "prettier": "^1.5.3"
+  },
+  "scripts": {
+    "start": "node build/app.js",
+    "dev": "NODE_ENV=development nodemon --exec npm run babel-node -- app.js",
+    "babel-node": "./node_modules/.bin/babel-node --ignore='node_modules'",
+    "test": "NODE_ENV=test BABEL_ENV=test node ./node_modules/.bin/mocha --timeout 5000 --require babel-polyfill --compilers js:babel-core/register --ui bdd",
+    "build": "babel . -d build --ignore node_modules,test,build,gulpfile.js && cp -R src/templates build/src/templates",
+    "preinstall": "rm -rf build",
+    "postinstall": "npm run build && gulp cachegoose:clear",
+    "deploy": "git push heroku master",
+    "rebuild": "git commit --allow-empty -m \"Rebuild\" && git push heroku master",
+    "clearcache": "gulp cachegoose:clear"
+  },
+  "engines": {
+    "node": "8.9.3",
+    "yarn": "1.5.1"
+  },
+  "flow": "flow",
+  "proxy": "http://localhost:3001"
+}

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -191,3 +191,21 @@ describe("postinstall-only", () => {
       expect(pkg["heroku-run-build-script"]).to.be.true;
     });
 });
+
+describe("postinstall-contains-run-build", () => {
+  let f = getFixture("postinstall-contains-run-build");
+  test
+    .stdout()
+    .do(() => cmd.run([f, "-y"]))
+    .it("removes postinstall", ctx => {
+      expect(ctx.stdout).to.contain("will be affected by upcoming changes");
+      expect(ctx.stdout).to.contain(
+        `We suggest moving the "postinstall" script to "heroku-postbuild" and opting in to the new behavior.`
+      );
+
+      let pkg = readJSON(f);
+      expect(pkg["heroku-run-build-script"]).to.be.true;
+      expect(pkg.scripts["heroku-postbuild"]).to.equal("npm run build && gulp cachegoose:clear")
+      expect(pkg["postinstall"]).to.be.undefined;
+    });
+});


### PR DESCRIPTION
Suggesting to move a postinstall script that contains "npm run build" to "build" results in the following:

`"build": "npm run build && other command"`

which is an infinite loop. This addresses it by detecting this situation and moving "postinstall" to "heroku-postbuild" instead.

![hyper 2019-03-07 15-54-15](https://user-images.githubusercontent.com/175496/53997501-4dea2f80-40f1-11e9-8584-d2bab1e3ed4b.png)
